### PR TITLE
Allows for excluding spell id's from the module. (#12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ CMakeLists.txt.user
 *.BACKUP.*
 *.BASE.*
 *.LOCAL.*
+*.conf
 
 #
 # IDE & other softwares

--- a/conf/mod_account_mount.conf.dist
+++ b/conf/mod_account_mount.conf.dist
@@ -11,3 +11,8 @@ Account.Mounts.Enable = 1
 # Announce the module when the player logs in?
 
 Account.Mounts.Announce = 0
+
+# Excluded Spell IDs (comma-separated, no space). See example below
+# Account.Mounts.ExcludedSpellIDs = 470,578,6777
+
+Account.Mounts.ExcludedSpellIDs = 0

--- a/src/mod_account_mount.cpp
+++ b/src/mod_account_mount.cpp
@@ -2,14 +2,34 @@
 #include "ScriptMgr.h"
 #include "Chat.h"
 #include "Player.h"
+#include <set>         // Required for std::set             -- might be redundant
+#include <sstream>     // Required for std::istringstream   -- might be redundant
+#include <string>      // Required for std::string          -- might be redundant
 
 class AccountMounts : public PlayerScript
 {
-    static const bool limitrace = false; // This set to true will only learn mounts from chars on the same team, do what you want.
+    static const bool limitrace = true; // This set to true will only learn mounts from chars on the same team, do what you want.
+    std::set<uint32> excludedSpellIds; // Set to hold the Spell IDs to be excluded
 
 public:
-    AccountMounts() : PlayerScript("AccountMounts") { }
-
+    AccountMounts() : PlayerScript("AccountMounts")
+    {
+        // Retrieve the string of excluded Spell IDs from the config file
+        std::string excludedSpellsStr = sConfigMgr->GetOption<std::string>("Account.Mounts.ExcludedSpellIDs", "");
+        // Proceed only if the configuration is not "0" or empty, indicating exclusions are specified
+        if (excludedSpellsStr != "0" && !excludedSpellsStr.empty())
+        {
+            std::istringstream spellStream(excludedSpellsStr);
+            std::string spellIdStr;
+            while (std::getline(spellStream, spellIdStr, ',')) {
+                uint32 spellId = static_cast<uint32>(std::stoul(spellIdStr));
+                if (spellId != 0) { // Ensure the spell ID is not 0, as 0 is used to indicate no exclusions
+                    excludedSpellIds.insert(spellId); // Add the Spell ID to the set of exclusions
+                }
+            }
+        }
+    }
+    
     void OnLogin(Player* pPlayer)
     {
         if (sConfigMgr->GetOption<bool>("Account.Mounts.Enable", true))
@@ -32,7 +52,7 @@ public:
                 uint32 race = fields[1].Get<uint8>();
 
                 if ((Player::TeamIdForRace(race) == Player::TeamIdForRace(pPlayer->getRace())) || !limitrace)
-                    Guids.push_back(result1->Fetch()[0].Get<uint32>());
+                    Guids.push_back(fields[0].Get<uint32>());
 
             } while (result1->NextRow());
 
@@ -52,9 +72,13 @@ public:
 
             for (auto& i : Spells)
             {
-                auto sSpell = sSpellStore.LookupEntry(i);
-                if (sSpell->Effect[0] == SPELL_EFFECT_APPLY_AURA && sSpell->EffectApplyAuraName[0] == SPELL_AURA_MOUNTED)
-                    pPlayer->learnSpell(sSpell->Id);
+                // Check if the spell is in the excluded list before learning it
+                if (excludedSpellIds.find(i) == excludedSpellIds.end())
+                {
+                    auto sSpell = sSpellStore.LookupEntry(i);
+                    if (sSpell->Effect[0] == SPELL_EFFECT_APPLY_AURA && sSpell->EffectApplyAuraName[0] == SPELL_AURA_MOUNTED)
+                        pPlayer->learnSpell(sSpell->Id);
+                }
             }
         }
     }


### PR DESCRIPTION
* Modified to allow for excluding certain spells from the module

* change of plans. let's load the spell ids from the config file instead, makes it a bit more versatile for others as well.

* Update mod_account_mount.cpp

* Update .gitignore

ignore .conf file, only commit .dist

* Update mod_account_mount.cpp

* Handle scenarios where no spell IDs are to be excluded

Modified the AccountMounts script to seamlessly handle scenarios where no spell IDs are to be excluded by interpreting "0" or an empty configuration string as no exclusion criteria. This update leverages the existing uint32 type for spell ID representation and enhances the script's flexibility in configuration management.

The change ensures that the AccountMounts script is more adaptable to server administrators' needs, allowing for a straightforward way to toggle spell ID exclusions.

Also added some code commenting

* fatal error: 'GetStringDefault' is deprecated

---------

<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- 
- 

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- 
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1.
2.
3.
